### PR TITLE
Update Jenkinsfile

### DIFF
--- a/XYZ_Task4/Jenkinsfile
+++ b/XYZ_Task4/Jenkinsfile
@@ -95,8 +95,8 @@ pipeline {
             steps {
                 withKubeConfig([credentialsId: 'certificate_file']) {
                     sh 'kubectl get pods -n xyz-tech'
-                    sh 'kubectl describe pods -n xyz-tech -l app=xyz-tech-app'
-                    sh 'kubectl logs -n xyz-tech -l app=xyz-tech-app --all-containers --tail=100'
+                    sh 'kubectl describe pods -n xyz-tech -l app=xyztechnologies'
+                    sh 'kubectl logs -n xyz-tech -l app=xyztechnologies --all-containers --tail=100'
                 }
             }
         }


### PR DESCRIPTION
Problem:

Jenkins pipeline uses: -l app=xyz-tech-app
Actual pod labels are: app=xyztechnologies

Solution: Update Jenkins Pipeline
stage('Check Deployed App') {
    steps {
        withKubeConfig([credentialsId: 'certificate_file']) {
            sh 'kubectl get pods -n xyz-tech'
            sh 'kubectl describe pods -n xyz-tech -l app=xyztechnologies'
            sh 'kubectl logs -n xyz-tech -l app=xyztechnologies --all-containers --tail=100'
        }
    }
}